### PR TITLE
Install latest Nginx version from official repos

### DIFF
--- a/nginx/tasks/setup-nginx.yml
+++ b/nginx/tasks/setup-nginx.yml
@@ -1,14 +1,24 @@
 ---
-  - name: install nginx
-    action: apt name=nginx
 
-  - name: write nginx.conf
-    action: template src=templates/nginx.conf.j2 dest=/etc/nginx/nginx.conf
-    notify:
-      - restart nginx
+- name: Add nginx repo key
+  apt_key:
+    url: "http://nginx.org/keys/nginx_signing.key"
 
-  - name: delete default vhost
-    action: file path=/etc/nginx/sites-enabled/default state=absent
-    only_if: "$delete_default_vhost"
-    notify:
-      - restart nginx
+- name: Add official APT repository
+  when: ansible_os_family == 'Debian'
+  apt_repository:
+    repo: "deb http://nginx.org/packages/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} nginx"
+
+- name: install latest nginx version
+  action: apt name=nginx state=latest
+
+- name: write nginx.conf
+  action: template src=templates/nginx.conf.j2 dest=/etc/nginx/nginx.conf
+  notify:
+    - restart nginx
+
+- name: delete default vhost
+  action: file path=/etc/nginx/sites-enabled/default state=absent
+  only_if: "$delete_default_vhost"
+  notify:
+    - restart nginx


### PR DESCRIPTION
If you use default Debian or Ubuntu repos, you'll get Nginx 1.4.x, which is really outdated and has lots of security bugs (check this: http://nginx.org/en/security_advisories.html ).
It's better if you configure Nginx official repo and install version >= 1.8.x

Hope this helps!
